### PR TITLE
ADDed checkboxes for product catalogue update to Feature and Enhancement Templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/2-feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/2-feature-request.yml
@@ -85,3 +85,11 @@ body:
     placeholder: As engineer, after creating the PBI, use the `Add tasklist` feature to add your new/planned/already defined SBIs.
   validations:
     required: false
+- type: checkboxes
+  id: productcataloguecb
+  attributes:
+    label: Product Catalogue Updated
+    description: (To be filled before finishing/closing/completing this ticket)
+    options:
+      - label: I have updated an existing or added a new item to the product catalogue to reflect the change(s) implemented in this PBI.
+        required: false

--- a/.github/ISSUE_TEMPLATE/2-feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/2-feature-request.yml
@@ -93,3 +93,5 @@ body:
     options:
       - label: I have updated an existing or added a new item to the product catalogue to reflect the change(s) implemented in this PBI.
         required: false
+      - label: It's not necessary to update the product catalogue due to this PBI.
+        required: false

--- a/.github/ISSUE_TEMPLATE/3-enhancement-request.yml
+++ b/.github/ISSUE_TEMPLATE/3-enhancement-request.yml
@@ -86,3 +86,11 @@ body:
     placeholder: As engineer, after creating the PBI, use the `Add tasklist` feature to add your new/planned/already defined SBIs.
   validations:
     required: false
+- type: checkboxes
+  id: productcataloguecb
+  attributes:
+    label: Product Catalogue Updated
+    description: (To be filled before finishing/closing/completing this ticket)
+    options:
+      - label: I have updated an existing or added a new item to the product catalogue to reflect the change(s) implemented in this PBI.
+        required: false

--- a/.github/ISSUE_TEMPLATE/3-enhancement-request.yml
+++ b/.github/ISSUE_TEMPLATE/3-enhancement-request.yml
@@ -94,3 +94,5 @@ body:
     options:
       - label: I have updated an existing or added a new item to the product catalogue to reflect the change(s) implemented in this PBI.
         required: false
+      - label: It's not necessary to update the product catalogue due to this PBI.
+        required: false


### PR DESCRIPTION
As discussed in https://github.com/sendance/cloud-client-docs/issues/6

I intentionally did not add a link to the respective product catalogues to keep it more flexible (people should know where to find it... e.g. linked in product backlog's description/Wiki).

Uppon approval, this gets into affect for all repositories which use the global template (i.e. haven't overwritten them locally).