### PR TITLE
REMOVE expected/actual behavior sections from bug report

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/1-bug-report.yml
@@ -29,7 +29,7 @@ body:
 - type: textarea
   attributes:
     label: Description
-    description: Provide a clear and concise description of the bug you encountered.
+    description: Provide a clear and concise description of the bug you encountered, what the expected behavior, and the current behavior is.
   validations:
     required: false
 - type: textarea
@@ -58,18 +58,6 @@ body:
     label: Last known working version
     description: If this is a regression, enter the last known working version (e.g. v1.2.3) 
     placeholder: v1.2.3
-- type: textarea
-  attributes:
-    label: Expected Behaviour
-    description: Provide a clear and concise description of what you expected to happen when performing the steps mentioned above.
-  validations:
-    required: false
-- type: textarea
-  attributes:
-    label: Actual Behaviour
-    description: Provide a clear and concise description of what actually happened when performing the steps. Be specific and provide any error messages or unexpected behavior encountered.
-  validations:
-    required: false
 - type: textarea
   attributes:
     label: Code Snippets


### PR DESCRIPTION
and instead add a hint to description. This was removed due to many redundancies in bug reports previously.

-------

This is an outcome of the cloud sprint retro q4-1/24 (see [notes](https://docs.google.com/document/d/11cLZsGt1Kt6BdqGNIG4DVwdpNT-19OEkw_Lf072K7j0/edit?tab=t.0)). We had lots of cases where the bug was described in the description section and then the same thing copied to "actual behavior" with the inverse being written to "expected behavior". e.g. 
```
- description: "label vanishes when clicking on xy"
- actual behavior: "label vanishes when clicking on xy"
- expected behavior: "label does not vanish when clicking on xy"
```

Creating bug reports with quite redundant contents. Since PBI bug reports are supposedly only created by engineers anymore now, it should be clear that the description should contain this information, anyway, without the need to redundantly state it explicitly again in another field. 

@POs please approve if this is reasonable to you.