### PR TITLE
REMOVEd mentions of tasklist feature

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/1-bug-report.yml
@@ -104,6 +104,6 @@ body:
   attributes:
     label: Solution Path
     description: (TO BE FILLED BY ENGINEER)
-    placeholder: As engineer, after creating the PBI, use the `Add tasklist` feature to add your new/planned/already defined SBIs.
+    placeholder: As engineer, after creating the PBI, use the `Create sub-issue / Add existing issue` feature to add your new/planned/already defined SBIs.
   validations:
     required: false

--- a/.github/ISSUE_TEMPLATE/10-sprint-backlog-item.yml
+++ b/.github/ISSUE_TEMPLATE/10-sprint-backlog-item.yml
@@ -31,8 +31,8 @@ body:
   attributes:
     label: Execution
     description: |
-      Add a list of (to-be- or already ) executed steps (optional: using the "tasklist" feature, see https://docs.github.com/en/issues/managing-your-tasks-with-tasklists/creating-a-tasklist).    
+      Add a list of (to-be- or already ) executed steps.    
     placeholder: |
-      e.g., Tasks: 1. Researched sensor basis options, 2. Order 2 most favorable ones 3. Build & test 2 samples  4. Evaluate data   
+      e.g., Tasks: 1. Researched sensor basis options, 2. Order 2 most favorable ones 3. Build & test 2 samples  4. Evaluate data 5. Write documentation
   validations:
     required: false

--- a/.github/ISSUE_TEMPLATE/2-feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/2-feature-request.yml
@@ -82,7 +82,7 @@ body:
   attributes:
     label: Solution Path
     description: (TO BE FILLED BY ENGINEER)
-    placeholder: As engineer, after creating the PBI, use the `Add tasklist` feature to add your new/planned/already defined SBIs.
+    placeholder: As engineer, after creating the PBI, use the `Create sub-issue / Add existing issue` feature to add your new/planned/already defined SBIs.
   validations:
     required: false
 - type: checkboxes

--- a/.github/ISSUE_TEMPLATE/3-enhancement-request.yml
+++ b/.github/ISSUE_TEMPLATE/3-enhancement-request.yml
@@ -83,7 +83,7 @@ body:
   attributes:
     label: Solution Path
     description: (TO BE FILLED BY ENGINEER)
-    placeholder: As engineer, after creating the PBI, use the `Add tasklist` feature to add your new/planned/already defined SBIs.
+    placeholder: As engineer, after creating the PBI, use the `Create sub-issue / Add existing issue` feature to add your new/planned/already defined SBIs.
   validations:
     required: false
 - type: checkboxes

--- a/.github/ISSUE_TEMPLATE/4-documentation-report.yml
+++ b/.github/ISSUE_TEMPLATE/4-documentation-report.yml
@@ -77,6 +77,6 @@ body:
   attributes:
     label: Solution Path
     description: (TO BE FILLED BY ENGINEER)
-    placeholder: As engineer, after creating the PBI, use the `Add tasklist` feature to add your new/planned/already defined SBIs.
+    placeholder: As engineer, after creating the PBI, use the `Create sub-issue / Add existing issue` feature to add your new/planned/already defined SBIs.
   validations:
     required: false

--- a/.github/ISSUE_TEMPLATE/5-testing-report.yml
+++ b/.github/ISSUE_TEMPLATE/5-testing-report.yml
@@ -71,6 +71,6 @@ body:
   attributes:
     label: Solution Path
     description: (TO BE FILLED BY ENGINEER)
-    placeholder: As engineer, after creating the PBI, use the `Add tasklist` feature to add your new/planned/already defined SBIs.
+    placeholder: As engineer, after creating the PBI, use the `Create sub-issue / Add existing issue` feature to add your new/planned/already defined SBIs.
   validations:
     required: false

--- a/.github/ISSUE_TEMPLATE/6-ci-report.yml
+++ b/.github/ISSUE_TEMPLATE/6-ci-report.yml
@@ -65,6 +65,6 @@ body:
   attributes:
     label: Solution Path
     description: (TO BE FILLED BY ENGINEER)
-    placeholder: As engineer, after creating the PBI, use the `Add tasklist` feature to add your new/planned/already defined SBIs.
+    placeholder: As engineer, after creating the PBI, use the `Create sub-issue / Add existing issue` feature to add your new/planned/already defined SBIs.
   validations:
     required: false

--- a/.github/ISSUE_TEMPLATE/7-support-request.yml
+++ b/.github/ISSUE_TEMPLATE/7-support-request.yml
@@ -89,6 +89,6 @@ body:
   attributes:
     label: Solution Path
     description: (TO BE FILLED BY ENGINEER)
-    placeholder: As engineer, after creating the PBI, use the `Add tasklist` feature to add your new/planned/already defined SBIs.
+    placeholder: As engineer, after creating the PBI, use the `Create sub-issue / Add existing issue` feature to add your new/planned/already defined SBIs.
   validations:
     required: false

--- a/.github/ISSUE_TEMPLATE/8-security-report.yml
+++ b/.github/ISSUE_TEMPLATE/8-security-report.yml
@@ -121,6 +121,6 @@ body:
   attributes:
     label: Solution Path
     description: (TO BE FILLED BY ENGINEER)
-    placeholder: As engineer, after creating the PBI, use the `Add tasklist` feature to add your new/planned/already defined SBIs. 
+    placeholder: As engineer, after creating the PBI, use the `Create sub-issue / Add existing issue` feature to add your new/planned/already defined SBIs. 
   validations:
     required: false

--- a/.github/ISSUE_TEMPLATE/9-research-request.yml
+++ b/.github/ISSUE_TEMPLATE/9-research-request.yml
@@ -77,6 +77,6 @@ body:
   attributes:
     label: Solution Path
     description: (TO BE FILLED BY ENGINEER)
-    placeholder: As engineer, after creating the PBI, use the `Add tasklist` feature to add your new/planned/already defined SBIs.
+    placeholder: As engineer, after creating the PBI, use the `Create sub-issue / Add existing issue` feature to add your new/planned/already defined SBIs.
   validations:
     required: false


### PR DESCRIPTION
Required change due to Github removing the tasklists feature by April 30th 2025. See https://github.blog/changelog/2025-02-18-github-issues-projects-february-18th-update/#tasklist-blocks-will-be-retired-and-replaced-with-sub-issues